### PR TITLE
fix: Add version propagation replacing semver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
       - run: cd snyk && npm install
       - run: cd snyk && git apply ../longformprojectname.patch
       - run: cd snyk && npm run build
+      - run: cd snyk && ./updateVersionInPackageFile.sh
       - run: cd snyk && npx pkg .
       - persist_to_workspace:
           root: .

--- a/updateVersionInPackageFile.sh
+++ b/updateVersionInPackageFile.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+version=$(git describe --tags)
+search='"description"'
+
+version=$(sed s/v// <<< $version)
+version="\"version\": \"${version}\",\n \
+   \"description\""
+
+sed -i "s/${search}/${version}/g" package.json


### PR DESCRIPTION
get version from tags and pushes it into package.json before build so it's available to cli version command.